### PR TITLE
Feat: axios interceptor 설정

### DIFF
--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -1,5 +1,6 @@
 import { tokenDataTypes } from '../state/react-query/hooks/types/auth';
-import client from './axiosClient';
+import { client } from './axiosClient/client';
+
 export const login = async (data: {
   email: string;
   password: string;

--- a/apis/axiosClient/client.ts
+++ b/apis/axiosClient/client.ts
@@ -1,0 +1,5 @@
+import axios, { AxiosInstance } from 'axios';
+
+export const client: AxiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+});

--- a/apis/axiosClient/index.ts
+++ b/apis/axiosClient/index.ts
@@ -1,7 +1,0 @@
-import axios, { AxiosInstance } from 'axios';
-
-const client: AxiosInstance = axios.create();
-
-client.defaults.baseURL = process.env.NEXT_PUBLIC_API_URL;
-
-export default client;

--- a/apis/axiosClient/interceptor.ts
+++ b/apis/axiosClient/interceptor.ts
@@ -1,0 +1,14 @@
+import { client } from './client';
+
+export const requestInterceptor = (accessToken: string) => {
+  client.interceptors.request.use(
+    function (config: any) {
+      config.headers.Authrozation = accessToken;
+      return config;
+    }
+    //function (error: any) {
+    // Do something with request error
+    //return Promise.reject(error);
+    //}
+  );
+};

--- a/state/react-query/hooks/auth.ts
+++ b/state/react-query/hooks/auth.ts
@@ -4,6 +4,7 @@ import { useMutation, UseMutationResult } from 'react-query';
 import uuid from 'react-uuid';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { githubLogin, login } from '../../../apis/auth';
+import { requestInterceptor } from '../../../apis/axiosClient/interceptor';
 import { LOGIN_METHOD } from '../../../constants/login';
 import { setCookie } from '../../../cookie/user-storage';
 import { ToastListState } from '../../recoil/toastList';
@@ -37,6 +38,7 @@ export default function UseLoginMutation(method: string): UseMutationResult {
       setUser({ accessToken: data.accessToken });
       // refresh는 쿠키에
       setCookie('refresh', data.refreshToken);
+      requestInterceptor(data.accessToken);
       router.push('/');
       setToast([
         { category: 'Success', message: '로그인에 성공했습니다!', id: uuid() },

--- a/state/recoil/user.ts
+++ b/state/recoil/user.ts
@@ -2,11 +2,12 @@ import { atom } from 'recoil';
 import { recoilKeys } from './recoilKeys';
 
 export type userStateType = {
-  id?: string;
-  accessToken?: string;
+  accessToken: string;
 };
 
 export const userState = atom<userStateType>({
   key: recoilKeys.atom.userState,
-  default: {},
+  default: {
+    accessToken: '',
+  },
 });


### PR DESCRIPTION
## 🎯 이슈번호
#23 

## ☁ 작업
API 요청할 때 http 요청 헤더의 authrozation에 accesstoken이 있어야 합니다.  따라서 axios interceptor를 이용하여 API 요청 보내기 직전에 http 헤더의 Authrozation에 accesstoken을 넣어주는 작업을 했습니다.

로그인에 성공하면 accesstoken을 requestInterceptor()함수로 보내준 후, requestInterceptor()함수에서는 API 요청 보내기 직전에 헤더의 authrozation에 accesstoken을 넣어주는 작업을 하도록 했습니다.
```
export const requestInterceptor = (accessToken: string) => {
  client.interceptors.request.use(
    function (config: any) {
      config.headers.Authrozation = accessToken;
      return config;
    }
    //function (error: any) {
    // Do something with request error
    //return Promise.reject(error);
    //}
  );
};
```

## 💭 기타
아래의 코드와 같이 (axios의 인스턴스를 만드는 곳)에서도 헤더의 authrozation에 값을 넣어줄 수 있다고 알고 있습니다.
그러나 여기에서는 게속 고정된 값이 들어가면 상관없지만, accesstoken은 refreshtoken을 이용하여 중간에 바뀌는 값이기 때문에, 이렇게 중간에 바뀌는 값은 아래의 코드에서 headers처럼 적용이 안된다고 알고 있어서 axios의 interceptor를 이용했습니다.
```
export const client: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
//headers: {'Authrozation': accessToken}
});
```


